### PR TITLE
Roles name fixes

### DIFF
--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -13,6 +13,8 @@ class Admin::RolesController < ApplicationController
   def create
     params[:role][:node_list] = params[:role][:nodes].reject {|key,value| value == "0" }.keys
     params[:role].delete(:nodes)
+    #HACK: Roles doesn't support spaces, so they are replaced by _
+    params[:role][:name].gsub!(/ /,'_')
     @role = Role.new(params[:role])
     @role.assign_nodes(params[:role][:node_list])
     @role.save
@@ -30,6 +32,7 @@ class Admin::RolesController < ApplicationController
   def update
     @role = Role.find(params[:id])
     params[:role][:node_list] = params[:role][:nodes].reject {|key,value| value == "0" }.keys
+    params[:role][:name].gsub!(/ /,'_')
     @role.update_attributes(params[:role])
     redirect_to role_path(@role)
   end

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -19,4 +19,4 @@
         %td= node.name
         %td= node.hostname
         %td= node.ip
-        %td= node.users
+        %td= node.users.join(', ') unless node.users.nil?

--- a/app/views/admin/roles/_form.html.haml
+++ b/app/views/admin/roles/_form.html.haml
@@ -1,6 +1,6 @@
 %p.long
   = f.label :name, "Name"
-  = f.text_field :name
+  = f.text_field :name, :value => @role.name.gsub('_',' ')
 %p.long
   = f.label :description, "Description"
   = f.text_area :description

--- a/app/views/admin/roles/_role.html.haml
+++ b/app/views/admin/roles/_role.html.haml
@@ -1,6 +1,6 @@
 .box#group
   %ul
-    %li= link_to role.name, role_path(role)
+    %li= link_to role.name.gsub('_',' '), role_path(role)
     %li
       Members:
       = role.nodes.size

--- a/app/views/admin/roles/index.html.haml
+++ b/app/views/admin/roles/index.html.haml
@@ -14,5 +14,5 @@
     %body
       - @roles.each do |role|
         %tr{:class => cycle("odd", "even")}
-          %td= link_to role.name, edit_admin_role_path(role.name)
+          %td= link_to role.name.gsub('_',' '), edit_admin_role_path(role.name)
           %td= role.nodes.size

--- a/app/views/roles/_groups.html.haml
+++ b/app/views/roles/_groups.html.haml
@@ -5,5 +5,5 @@
   %body
     - roles.each do |role|
       %tr
-        %td= link_to role.name, role_path(role.name)
+        %td= link_to role.name.gsub('_',' '), role_path(role.name)
         %td= role.nodes.size

--- a/app/views/roles/_role.html.haml
+++ b/app/views/roles/_role.html.haml
@@ -1,6 +1,6 @@
 .box#group
   %ul
-    %li= link_to role.name, role_path(role.name)
+    %li= link_to role.name.gsub('_',' '), role_path(role.name)
     %li
       Members:
       = role.nodes.size

--- a/app/views/roles/show.html.haml
+++ b/app/views/roles/show.html.haml
@@ -1,4 +1,4 @@
-%h1= @role.name
+%h1= @role.name.gsub('_',' ')
 
 %p.description= @role.description
 


### PR DESCRIPTION
Roles' name can't have **spaces** so when the user create a "_group_" (actually a _role_) with spaces it crash.

The patch replace _spaces_ with "_" when the role is created or updated and replaced back at the HTML for the view.

There is also a minor fix in a commit about the list of user displayed for each node.
