### PR TITLE
UI: moved the 'New role' link to the left

### DIFF
--- a/app/views/admin/roles/index.html.haml
+++ b/app/views/admin/roles/index.html.haml
@@ -3,10 +3,9 @@
 / #groups
 /   = render @roles
 
-.float_right
-  = link_to "New group", new_admin_role_path()
-.clear
 #groups
+  .float_left
+    = link_to "New group", new_admin_role_path()
   %table.full.tablesorter
     %thead
       %th Name


### PR DESCRIPTION
The client ask to move the link. Before it wasn't a search box, so was ok, but now look too heavy the right side.
